### PR TITLE
Add GitHub Copilot support

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,7 @@ import { OllamaHandler } from "./providers/ollama"
 import { LmStudioHandler } from "./providers/lmstudio"
 import { GeminiHandler } from "./providers/gemini"
 import { OpenAiNativeHandler } from "./providers/openai-native"
+import { CopilotHandler } from "./providers/copilot"
 import { ApiStream } from "./transform/stream"
 
 export interface ApiHandler {
@@ -37,6 +38,8 @@ export function buildApiHandler(configuration: ApiConfiguration): ApiHandler {
 			return new GeminiHandler(options)
 		case "openai-native":
 			return new OpenAiNativeHandler(options)
+		case "copilot":
+			return new CopilotHandler(options)
 		default:
 			return new AnthropicHandler(options)
 	}

--- a/src/api/providers/copilot.ts
+++ b/src/api/providers/copilot.ts
@@ -1,0 +1,35 @@
+import { ApiHandler } from "../index";
+import { ApiStream } from "../transform/stream";
+import { ModelInfo } from "../../shared/api";
+import * as vscode from "vscode";
+
+export class CopilotHandler implements ApiHandler {
+  async *createMessage(systemPrompt: string, messages: any[]): ApiStream {
+    const copilot = vscode.extensions.getExtension("GitHub.copilot");
+    if (!copilot) {
+      throw new Error("GitHub Copilot extension is not installed.");
+    }
+
+    const copilotApi = copilot.exports;
+    const response = await copilotApi.sendPrompt(systemPrompt, messages);
+
+    for (const chunk of response) {
+      yield {
+        type: "text",
+        text: chunk,
+      };
+    }
+  }
+
+  getModel(): { id: string; info: ModelInfo } {
+    return {
+      id: "github-copilot",
+      info: {
+        maxTokens: 4096,
+        contextWindow: 8192,
+        supportsImages: false,
+        supportsPromptCache: false,
+      },
+    };
+  }
+}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -39,6 +39,7 @@ type SecretKey =
 	| "openAiApiKey"
 	| "geminiApiKey"
 	| "openAiNativeApiKey"
+	| "copilot"
 type GlobalStateKey =
 	| "apiProvider"
 	| "apiModelId"
@@ -60,6 +61,7 @@ type GlobalStateKey =
 	| "openRouterModelId"
 	| "openRouterModelInfo"
 	| "autoApprovalSettings"
+	| "copilot"
 
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
@@ -923,6 +925,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			customInstructions,
 			taskHistory,
 			autoApprovalSettings,
+			copilot,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -952,6 +955,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("customInstructions") as Promise<string | undefined>,
 			this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
 			this.getGlobalState("autoApprovalSettings") as Promise<AutoApprovalSettings | undefined>,
+			this.getGlobalState("copilot") as Promise<string | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -994,6 +998,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				azureApiVersion,
 				openRouterModelId,
 				openRouterModelInfo,
+				copilot,
 			},
 			lastShownAnnouncementId,
 			customInstructions,
@@ -1074,6 +1079,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			"openAiApiKey",
 			"geminiApiKey",
 			"openAiNativeApiKey",
+			"copilot",
 		]
 		for (const key of secretKeys) {
 			await this.storeSecret(key, undefined)


### PR DESCRIPTION
Add GitHub Copilot as an API provider without requiring an API key.

* **src/api/index.ts**
  - Import `CopilotHandler` from `./providers/copilot`.
  - Add `copilot` case in `buildApiHandler` function to return `CopilotHandler`.

* **src/api/providers/copilot.ts**
  - Create `CopilotHandler` class implementing `ApiHandler` interface.
  - Implement `createMessage` method to send prompts to Copilot using VS Code's APIs.
  - Implement `getModel` method to return Copilot model information.

* **src/core/webview/ClineProvider.ts**
  - Add `copilot` to `SecretKey` and `GlobalStateKey` types.
  - Update `getState` method to include `copilot` configuration.
  - Update `updateGlobalState` method to handle `copilot` configuration.

